### PR TITLE
fix build failed on Windows

### DIFF
--- a/include/pscm/common_def.h
+++ b/include/pscm/common_def.h
@@ -10,7 +10,7 @@
   SPDLOG_ERROR("Exception occurred here: {}", msg);                                                                    \
   throw ::pscm::Exception(msg)
 #define PSCM_ASSERT(e)                                                                                                 \
-  if (__builtin_expect(!(e), 0)) {                                                                                     \
+  if (!(e)) {                                                                                                          \
     SPDLOG_ERROR("ASSERT FAILED here: {}", #e);                                                                        \
     assert(e);                                                                                                         \
   }                                                                                                                    \


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

error C3861: '__builtin_expect': identifier not found

https://github.com/PikachuHy/pscm/actions/runs/4517889613/jobs/7957404912#step:7:62

## What is changing

## Example


